### PR TITLE
Default to Sonatype OSS snapshot repo when property isn't defined

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,10 @@ buildscript {
 
 repositories {
     mavenCentral()
+
+    def snapshotRepoUrl = project.hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL : 'https://oss.sonatype.org/content/repositories/snapshots'
     maven {
-        url SNAPSHOT_REPOSITORY_URL
+        url snapshotRepoUrl
     }
 }
 


### PR DESCRIPTION
This will allow regular folks who clone the repo and try to build it to have a working build, while still allowing people who have that property set somewhere in their gradle infrastructure to override it.
