### PR TITLE
Source java version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ apply from: 'build-scripts/gradle-mvn-push.gradle'
 
 version = VERSION_NAME
 
+sourceCompatibility = JavaVersion.VERSION_1_7
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.1'
 }


### PR DESCRIPTION
(Note: This includes the changes from #3 because without that I can't build the project. #3 is intended to be merged first.)

Right now, the 0.10.0-SNAPSHOT in the Sonatype OSS snapshot repo is built with Java 8, rendering it useless for its intended purpose of working with Android projects. This change will treat the source as Java 7 source and generate Java 7 classfiles.
